### PR TITLE
Update to support WebGoat 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ There are several configurable properties that you can use to simulate a variety
 >
 >   -v verbose
 
+**Note:** Sheepdog expects an account registered on WebGoat with a username & password set to `guest2`. This is a concession for WebGoat 8 since the default `guest` account was removed and usernames/passwords with <6 characters are no longer allowed.
+
 
 ## Sample usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,11 @@
   </organization>
 
   <version>1.0-SNAPSHOT</version>
+
+  <properties>
+      <maven.compiler.source>1.6</maven.compiler.source>
+      <maven.compiler.target>1.6</maven.compiler.target>
+  </properties>
   
   <developers>
      <developer>

--- a/src/main/java/com/contrastsecurity/sheepdog/AttackThread.java
+++ b/src/main/java/com/contrastsecurity/sheepdog/AttackThread.java
@@ -93,10 +93,7 @@ public class AttackThread extends Thread {
                 }
                 String page = lessons.get( RANDOM.nextInt( lessons.size() ) );
                 String[] parts = page.split( "/" );
-                String lesson = "attack?Screen=" + parts[1] + "&menu=" + parts[2];
-                if ( parts.length > 3 ) {
-                    lesson += "&stage=" + parts[3];
-                }
+                String lesson = parts[1] + ".lesson";
                 String form = sendGet( lesson, false );
                 scan( lesson, form, attackPercent );
             } catch( Exception e ) {
@@ -127,10 +124,10 @@ public class AttackThread extends Thread {
     }
 
 
-    // "link": "#attack/3821/2000"
+    // "link": "#lesson/3821/2000"
     private List<String> parseLessons(String lessons) {
         List<String> allMatches = new ArrayList<String>();
-        Matcher m = Pattern.compile("#(attack.*?)\"").matcher(lessons);
+        Matcher m = Pattern.compile("#(lesson.*?)\"").matcher(lessons);
         while (m.find()) {
             String page = m.group();
             if(verbose) {

--- a/src/main/java/com/contrastsecurity/sheepdog/AttackThread.java
+++ b/src/main/java/com/contrastsecurity/sheepdog/AttackThread.java
@@ -72,7 +72,7 @@ public class AttackThread extends Thread {
             credentials.add(new BasicNameValuePair("username", "guest"));
             credentials.add(new BasicNameValuePair("password", "guest"));
 
-            sendPost( "j_spring_security_check", credentials );
+            sendPost( "login", credentials );
             sendGet( "welcome.mvc", false );
             
             String json = sendGet( "service/lessonmenu.mvc", false );        

--- a/src/main/java/com/contrastsecurity/sheepdog/LoginException.java
+++ b/src/main/java/com/contrastsecurity/sheepdog/LoginException.java
@@ -1,0 +1,13 @@
+package com.contrastsecurity.sheepdog;
+
+import org.apache.http.NameValuePair;
+
+import java.util.List;
+
+public class LoginException extends Exception {
+
+    public LoginException(List<NameValuePair> credentials) {
+        super("Invalid credentials " + credentials + " supplied. Did you register an account on WatchDog with these" +
+                " credentials?");
+    }
+}


### PR DESCRIPTION
Update SheepDog to work with the current latest version of WebGoat (#2). This does not include backwards compatibility, although adding this functionality in for WebGoat 7 support would not be difficult if desired.

Notable changes:

- Enforce compilation on Java 1.6+
- Update to use new WebGoat login URL
- Throw exception to fail fast on invalid login credentials
- Update default credentials**
- Use new pattern/URL layout for polling lessons

**WebGoat 8 does not come with a guest account already registered, and does not allow usernames or passwords with <6 characters, so I went with `guest2:guest2` as the default. I debated adding the ability to pass in credentials via command line or env variables but decided it wasn't worth the time investment when it's so easy to register a throwaway account.